### PR TITLE
fix: reduce time under mutexes

### DIFF
--- a/read.go
+++ b/read.go
@@ -18,14 +18,13 @@ func (d *Driver) Read(collection, resource string, v any) error {
 		return ErrNoResource
 	}
 
-	mutex := d.getMutex(collection)
-
-	mutex.Lock()
-	defer mutex.Unlock()
-
 	record := filepath.Join(d.dir, collection, resource)
 
+	mutex := d.getMutex(collection)
+	mutex.Lock()
 	b, err := os.ReadFile(record + ".json")
+	mutex.Unlock()
+
 	if err != nil {
 		return fmt.Errorf("read file: %w", err)
 	}

--- a/write.go
+++ b/write.go
@@ -16,6 +16,11 @@ func (d *Driver) Write(collection, resource string, v any) error {
 		return ErrNoResource
 	}
 
+	b, err := json.MarshalIndent(v, "", "\t")
+	if err != nil {
+		return fmt.Errorf("marshal data: %w", err)
+	}
+
 	mutex := d.getMutex(collection)
 
 	mutex.Lock()
@@ -27,15 +32,9 @@ func (d *Driver) Write(collection, resource string, v any) error {
 		return fmt.Errorf("make dir: %w", err)
 	}
 
-	b, err := json.MarshalIndent(v, "", "\t")
+	f := filepath.Join(dir, resource+extension)
 
-	if err != nil {
-		return fmt.Errorf("marshal data: %w", err)
-	}
-
-	dir = filepath.Join(dir, resource+extension)
-
-	err = os.WriteFile(dir, b, 0600)
+	err = os.WriteFile(f, b, 0600)
 	if err != nil {
 		return fmt.Errorf("write file: %w", err)
 	}


### PR DESCRIPTION
This change limits the time spent under mutex control for both read and write operations. This does not immediately improve performance, but if future development supports concurrent access, there will be less waiting for mutex to release.

# Testing

## Functional

```
❯ go run examples/example.go 
[{Albert 6} {John 1} {Neo 5} {Paul 2} {Robert 3} {Vince 4}]
```

## Performance

I put some timestamp logging around parts of the code. Leaving `json.unmarshal` in `read.go` and `json.marshal` in `write.go` outside of mutex lock significantly reduces the locking time. I tested on a file with 1000 simple records (based on `Student` struct).
- For reading 35us instead of (1816 + 35)us, 98% reduction
- For writing 96us instead of (1197 + 96)us, 93% reduction

Testing data:
```
READ
----------------------
get mutex: 444ns
read file: 35.022µs
unlock mutex: 78ns
unmarshal: 1.816244ms


WRITE
----------------------
marshal: 1.197369ms
get mutex: 912ns
mkdir: 69.951µs
write file: 96.428µs
```