### PR TITLE
feat: add filter for read

### DIFF
--- a/examples/example.go
+++ b/examples/example.go
@@ -37,20 +37,36 @@ func main() {
 		})
 	}
 
+	filter := []string{"Paul", "Robert", "Albert"} // read filtered records from database
+	filtered, err := db.ReadFiltered("students", filter)
+	if err != nil {
+		log.Fatalln(err)
+	}
+
+	filteredUsers := []Student{}
+
+	for _, f := range filtered {
+		var student Student
+		json.Unmarshal([]byte(f), &student)
+		filteredUsers = append(filteredUsers, student)
+	}
+
+	fmt.Printf("Filtered %d of expected %d students: %v\n", len(filteredUsers), len(filter), filteredUsers)
+
 	records, err := db.ReadAll("students") // read all records from database
 	if err != nil {
 		log.Fatalln(err)
 	}
 
-	allusers := []Student{}
+	allUsers := []Student{}
 
 	for _, f := range records {
 		var student Student
 		json.Unmarshal([]byte(f), &student)
-		allusers = append(allusers, student)
+		allUsers = append(allUsers, student)
 	}
 
-	fmt.Println(allusers)
+	fmt.Printf("All users: %v\n", allUsers)
 
 	err = db.DeleteResource("students", "John")
 	if err != nil { // delete a single document


### PR DESCRIPTION
Adds a new read function that allows specifying a list of resource keys to act as a filter for the returned results.

The same can be achieved using the existing functions:
- Using Read multiple times by requesting a next resource on each iteration. The difference with the proposed solution is that ReadFiltered keeps a mutex open and so avoids nonrepeatable reads.
- Using ReadAll and filtering on the client side. This is likely just wasteful as it fetches all the records regardless of the selection that the client requested.